### PR TITLE
Added warning to user creation

### DIFF
--- a/docs/webpanel/users.md
+++ b/docs/webpanel/users.md
@@ -4,6 +4,9 @@ title: Adding Users
 description: How to authorize new users on your API
 ---
 
+:::caution At least one server is required to add users
+You need to have one server created or imported in MCSS to make this panel appear.  
+:::
 
 On the `Web Panel` page you will see a button labeled `Manage Users & API Keys`.<br/>
 From this window you will be able to manage panel users.


### PR DESCRIPTION
This warning tells the user that a server must exist in MCSS for the Web Panel page to appear. That's required because the user creation wizard is only accessible from the Web Panel page.

## Feel free to edit the message, this is just a quick 'n' dirty message.  
This page should also contain the new User creation from the web panel (?)